### PR TITLE
Add streams for File Read/Write

### DIFF
--- a/Fantome.League/IO/AiMesh/AiMeshFile.cs
+++ b/Fantome.League/IO/AiMesh/AiMeshFile.cs
@@ -28,8 +28,18 @@ namespace Fantome.Libraries.League.IO.AiMesh
         /// </summary>
         /// <param name="fileLocation">The location to read from</param>
         public AiMeshFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+           
+        }
+
+        /// <summary>
+        /// Reads an <see cref="AiMeshFile"/> from the specified stream
+        /// </summary>
+        /// <param name="stream">Stream to read from</param>
+        public AiMeshFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
                 if (magic != "r3d2aims")
@@ -60,7 +70,16 @@ namespace Fantome.Libraries.League.IO.AiMesh
         /// <param name="fileLocation">The location to write to</param>
         public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileLocation)))
+            Write(File.Create(fileLocation));
+        }
+
+        /// <summary>
+        /// Writes this <see cref="AiMeshFile"/> to the specified stream
+        /// </summary>
+        /// <param name="stream">Stream to write to</param>
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write(Encoding.ASCII.GetBytes("r3d2aims"));
                 bw.Write((uint)2);

--- a/Fantome.League/IO/BIN/BINFile.cs
+++ b/Fantome.League/IO/BIN/BINFile.cs
@@ -24,8 +24,18 @@ namespace Fantome.Libraries.League.IO.BIN
         /// </summary>
         /// <param name="fileLocation">The location to read from</param>
         public BINFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="BINFile"/> from the specified stream
+        /// </summary>
+        /// <param name="stream">Straem to read from</param>
+        public BINFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
                 if (magic != "PROP")
@@ -61,7 +71,16 @@ namespace Fantome.Libraries.League.IO.BIN
         /// <param name="fileLocation">The location to write to</param>
         public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.Open(fileLocation, FileMode.Create)))
+            Write(File.Create(fileLocation));
+        }
+
+        /// <summary>
+        /// Writes this <see cref="BINFile"/> to the specified stream
+        /// </summary>
+        /// <param name="stream">The stream to write to</param>
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write(Encoding.ASCII.GetBytes("PROP"));
                 bw.Write((uint)2);

--- a/Fantome.League/IO/FX/FXFile.cs
+++ b/Fantome.League/IO/FX/FXFile.cs
@@ -9,10 +9,14 @@ namespace Fantome.Libraries.League.IO.FX
     {
         public List<FXTrack> Tracks { get; private set; } = new List<FXTrack>();
         public List<string> TargetBones { get; private set; } = new List<string>();
-
         public FXFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+
+        }
+        public FXFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 for (int i = 0; i < 8; i++)
                 {
@@ -44,7 +48,11 @@ namespace Fantome.Libraries.League.IO.FX
 
         public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileLocation)))
+            Write(File.Create(fileLocation));
+        }
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 foreach (FXTrack track in this.Tracks)
                 {

--- a/Fantome.League/IO/Inibin/InibinFile.cs
+++ b/Fantome.League/IO/Inibin/InibinFile.cs
@@ -7,9 +7,15 @@ namespace Fantome.Libraries.League.IO.Inibin
     public class InibinFile
     {
         public List<InibinSet> Sets { get; private set; } = new List<InibinSet>();
+
         public InibinFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+
+        }
+        public InibinFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 uint version = br.ReadByte();
 
@@ -87,10 +93,14 @@ namespace Fantome.Libraries.League.IO.Inibin
                 }
             }
         }
-
         public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileLocation)))
+            Write(File.Create(fileLocation));
+        }
+
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 ushort stringDataLength = 0;
                 InibinFlags flags = 0;

--- a/Fantome.League/IO/LightDat/LightDatFile.cs
+++ b/Fantome.League/IO/LightDat/LightDatFile.cs
@@ -11,23 +11,32 @@ namespace Fantome.Libraries.League.IO.LightDat
         {
             this.Lights = lights;
         }
-
         public LightDatFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (StreamReader sr = new StreamReader(fileLocation))
+
+        }
+        public LightDatFile(Stream stream)
+        {
+            using (StreamReader sr = new StreamReader(stream))
             {
-                while(!sr.EndOfStream)
+                while (!sr.EndOfStream)
                 {
                     this.Lights.Add(new LightDatLight(sr));
                 }
-            }        
+            }
         }
 
         public void Write(string fileLocation)
         {
-            using (StreamWriter sw = new StreamWriter(fileLocation))
+            Write(File.Create(fileLocation));
+        }
+
+        private void Write(Stream stream)
+        {
+            using (StreamWriter sw = new StreamWriter(stream))
             {
-                foreach(LightDatLight light in this.Lights)
+                foreach (LightDatLight light in this.Lights)
                 {
                     light.Write(sw);
                 }

--- a/Fantome.League/IO/LightEnvironment/LightEnvironmentFile.cs
+++ b/Fantome.League/IO/LightEnvironment/LightEnvironmentFile.cs
@@ -13,11 +13,17 @@ namespace Fantome.Libraries.League.IO.LightEnvironment
         }
 
         public LightEnvironmentFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (StreamReader sr = new StreamReader(fileLocation))
+
+        }
+
+        public LightEnvironmentFile(Stream stream)
+        {
+            using (StreamReader sr = new StreamReader(stream))
             {
                 string lightVersion = sr.ReadLine();
-                while(!sr.EndOfStream)
+                while (!sr.EndOfStream)
                 {
                     this.Lights.Add(new LightEnvironmentLight(sr));
                 }
@@ -26,8 +32,13 @@ namespace Fantome.Libraries.League.IO.LightEnvironment
 
         public void Write(string fileLocation)
         {
-            using (StreamWriter sw = new StreamWriter(fileLocation))
-            {
+            Write(File.Create(fileLocation));
+        }
+
+        private void Write(Stream stream)
+        {
+            using (StreamWriter sw = new StreamWriter(stream))
+            { 
                 sw.WriteLine("3");
 
                 foreach(LightEnvironmentLight light in this.Lights)

--- a/Fantome.League/IO/LightGrid/LightGridFile.cs
+++ b/Fantome.League/IO/LightGrid/LightGridFile.cs
@@ -13,9 +13,15 @@ namespace Fantome.Libraries.League.IO.LightGrid
         public LightGridSun Sun { get; private set; }
         public List<ColorRGBAVector4Byte> Grid { get; private set; } = new List<ColorRGBAVector4Byte>();
 
+
         public LightGridFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+
+        }
+        public LightGridFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 this.Version = br.ReadUInt32();
                 this._gridOffset = br.ReadUInt32();
@@ -32,7 +38,11 @@ namespace Fantome.Libraries.League.IO.LightGrid
 
         public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.Open(fileLocation, FileMode.Create)))
+            Write(File.Create(fileLocation));
+        }
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write(this.Version);
                 bw.Write(this._gridOffset);

--- a/Fantome.League/IO/MOB/MOBFile.cs
+++ b/Fantome.League/IO/MOB/MOBFile.cs
@@ -15,8 +15,13 @@ namespace Fantome.Libraries.League.IO.MOB
         }
 
         public MOBFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+
+        }
+        public MOBFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
                 if (magic != "OPAM")
@@ -42,7 +47,12 @@ namespace Fantome.Libraries.League.IO.MOB
 
         public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileLocation)))
+            Write(File.Create(fileLocation));
+        }
+
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write(Encoding.ASCII.GetBytes("OPAM"));
                 bw.Write((uint)2);

--- a/Fantome.League/IO/MapParticles/MapParticlesFile.cs
+++ b/Fantome.League/IO/MapParticles/MapParticlesFile.cs
@@ -13,9 +13,14 @@ namespace Fantome.Libraries.League.IO.MapParticles
         }
 
         public MapParticlesFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
+        {
+
+        }
+        public MapParticlesFile(Stream stream)
         {
             this.Particles = new List<MapParticlesParticle>();
-            using (StreamReader sr = new StreamReader(fileLocation))
+            using (StreamReader sr = new StreamReader(stream))
             {
                 while (!sr.EndOfStream)
                 {
@@ -26,7 +31,12 @@ namespace Fantome.Libraries.League.IO.MapParticles
 
         public void Write(string fileLocation)
         {
-            using (StreamWriter sw = new StreamWriter(fileLocation))
+            Write(File.Create(fileLocation));
+        }
+
+        public void Write(Stream stream)
+        {
+            using (StreamWriter sw = new StreamWriter(stream))
             {
                 foreach (MapParticlesParticle particle in this.Particles)
                 {

--- a/Fantome.League/IO/MaterialLibrary/MaterialLibraryFile.cs
+++ b/Fantome.League/IO/MaterialLibrary/MaterialLibraryFile.cs
@@ -11,8 +11,13 @@ namespace Fantome.Libraries.League.IO.MaterialLibrary
         public MaterialLibraryFile() { }
 
         public MaterialLibraryFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (StreamReader sr = new StreamReader(fileLocation))
+
+        }
+        public MaterialLibraryFile(Stream stream)
+        {
+            using (StreamReader sr = new StreamReader(stream))
             {
                 while (!sr.EndOfStream)
                 {
@@ -26,7 +31,12 @@ namespace Fantome.Libraries.League.IO.MaterialLibrary
 
         public void Write(string fileLocation)
         {
-            using (StreamWriter sw = new StreamWriter(fileLocation))
+            Write(File.Create(fileLocation));
+        }
+
+        public void Write(Stream stream)
+        {
+            using (StreamWriter sw = new StreamWriter(stream))
             {
                 foreach (MaterialLibraryMaterial material in this.Materials)
                 {

--- a/Fantome.League/IO/NVR/NVRFile.cs
+++ b/Fantome.League/IO/NVR/NVRFile.cs
@@ -13,96 +13,95 @@ namespace Fantome.Libraries.League.IO.NVR
         public List<NVRMesh> Meshes { get; private set; }
 
         public NVRFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.Open(fileLocation, FileMode.Open)))
+
+        }
+        public NVRFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
-                this.Read(br);
+                //Reading magic and version
+                string magic = ASCIIEncoding.ASCII.GetString(br.ReadBytes(4));
+                if (magic != "NVR\0")
+                {
+                    throw new InvalidFileMagicException();
+                }
+                this.MajorVersion = br.ReadInt16();
+                this.MinorVersion = br.ReadInt16();
+
+                //Reading the counts
+                int materialsCount = br.ReadInt32();
+                int vertexBufferCount = br.ReadInt32();
+                int indexBufferCount = br.ReadInt32();
+                int meshesCount = br.ReadInt32();
+                int nodesCount = br.ReadInt32();
+
+                //Parse content
+                NVRBuffers buffers = new NVRBuffers();
+                for (int i = 0; i < materialsCount; i++)
+                {
+                    buffers.Materials.Add(new NVRMaterial(br, (MajorVersion == 8 && MinorVersion == 1 ? true : false)));
+                }
+                for (int i = 0; i < vertexBufferCount; i++)
+                {
+                    buffers.VertexBuffers.Add(new NVRVertexBuffer(br));
+                }
+                for (int i = 0; i < indexBufferCount; i++)
+                {
+                    buffers.IndexBuffers.Add(new NVRIndexBuffer(br));
+                }
+                for (int i = 0; i < meshesCount; i++)
+                {
+                    buffers.Meshes.Add(new NVRMesh(br, buffers, (MajorVersion == 8 && MinorVersion == 1 ? true : false)));
+                }
+                // Unused
+                for (int i = 0; i < nodesCount; i++)
+                {
+                    buffers.Nodes.Add(new NVRNode(br, buffers));
+                }
+
+                this.Meshes = buffers.Meshes;
             }
         }
 
-        public void Read(BinaryReader br)
+        public void Write(string fileLocation)
         {
-            //Reading magic and version
-            string magic = ASCIIEncoding.ASCII.GetString(br.ReadBytes(4));
-            if (magic != "NVR\0")
-            {
-                throw new InvalidFileMagicException();
-            }
-            this.MajorVersion = br.ReadInt16();
-            this.MinorVersion = br.ReadInt16();
-
-            //Reading the counts
-            int materialsCount = br.ReadInt32();
-            int vertexBufferCount = br.ReadInt32();
-            int indexBufferCount = br.ReadInt32();
-            int meshesCount = br.ReadInt32();
-            int nodesCount = br.ReadInt32();
-
-            //Parse content
-            NVRBuffers buffers = new NVRBuffers();
-            for (int i = 0; i < materialsCount; i++)
-            {
-                buffers.Materials.Add(new NVRMaterial(br, (MajorVersion == 8 && MinorVersion == 1 ? true : false)));
-            }
-            for (int i = 0; i < vertexBufferCount; i++)
-            {
-                buffers.VertexBuffers.Add(new NVRVertexBuffer(br));
-            }
-            for (int i = 0; i < indexBufferCount; i++)
-            {
-                buffers.IndexBuffers.Add(new NVRIndexBuffer(br));
-            }
-            for (int i = 0; i < meshesCount; i++)
-            {
-                buffers.Meshes.Add(new NVRMesh(br, buffers, (MajorVersion == 8 && MinorVersion == 1 ? true : false)));
-            }
-            // Unused
-            for (int i = 0; i < nodesCount; i++)
-            {
-                buffers.Nodes.Add(new NVRNode(br, buffers));
-            }
-
-            this.Meshes = buffers.Meshes;
+            Write(File.Create(fileLocation));
         }
-
-        public void Save(string fileLocation)
+        public void Write(Stream stream)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.Open(fileLocation, FileMode.Create)))
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
-                this.Write(bw);
-            }
-        }
-
-        private void Write(BinaryWriter bw)
-        {
-            NVRBuffers buffers = this.GenerateBuffers();
-            bw.Write(ASCIIEncoding.ASCII.GetBytes("NVR\0"));
-            bw.Write(this.MajorVersion);
-            bw.Write(this.MinorVersion);
-            bw.Write(buffers.Materials.Count);
-            bw.Write(buffers.VertexBuffers.Count);
-            bw.Write(buffers.IndexBuffers.Count);
-            bw.Write(buffers.Meshes.Count);
-            bw.Write(buffers.Nodes.Count);
-            foreach (NVRMaterial material in buffers.Materials)
-            {
-                material.Write(bw);
-            }
-            foreach (NVRVertexBuffer vertBuffer in buffers.VertexBuffers)
-            {
-                vertBuffer.Write(bw);
-            }
-            foreach (NVRIndexBuffer indBuffer in buffers.IndexBuffers)
-            {
-                indBuffer.Write(bw);
-            }
-            foreach (NVRMesh mesh in buffers.Meshes)
-            {
-                mesh.Write(bw);
-            }
-            foreach (NVRNode node in buffers.Nodes)
-            {
-                node.Write(bw);
+                NVRBuffers buffers = this.GenerateBuffers();
+                bw.Write(ASCIIEncoding.ASCII.GetBytes("NVR\0"));
+                bw.Write(this.MajorVersion);
+                bw.Write(this.MinorVersion);
+                bw.Write(buffers.Materials.Count);
+                bw.Write(buffers.VertexBuffers.Count);
+                bw.Write(buffers.IndexBuffers.Count);
+                bw.Write(buffers.Meshes.Count);
+                bw.Write(buffers.Nodes.Count);
+                foreach (NVRMaterial material in buffers.Materials)
+                {
+                    material.Write(bw);
+                }
+                foreach (NVRVertexBuffer vertBuffer in buffers.VertexBuffers)
+                {
+                    vertBuffer.Write(bw);
+                }
+                foreach (NVRIndexBuffer indBuffer in buffers.IndexBuffers)
+                {
+                    indBuffer.Write(bw);
+                }
+                foreach (NVRMesh mesh in buffers.Meshes)
+                {
+                    mesh.Write(bw);
+                }
+                foreach (NVRNode node in buffers.Nodes)
+                {
+                    node.Write(bw);
+                }
             }
         }
 

--- a/Fantome.League/IO/OBJ/OBJFile.cs
+++ b/Fantome.League/IO/OBJ/OBJFile.cs
@@ -47,9 +47,16 @@ namespace Fantome.Libraries.League.IO.OBJ
             }
         }
 
-        public OBJFile(string Location)
+
+        public OBJFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (StreamReader sr = new StreamReader(Location))
+
+        }
+
+        public OBJFile(Stream stream)
+        {
+            using (StreamReader sr = new StreamReader(stream))
             {
                 while (sr.BaseStream.Position != sr.BaseStream.Length)
                 {
@@ -58,9 +65,14 @@ namespace Fantome.Libraries.League.IO.OBJ
             }
         }
 
-        public void Write(string Location)
+        public void Write(string fileLocation)
         {
-            using (StreamWriter sw = new StreamWriter(Location))
+            Write(File.Create(fileLocation));
+        }
+
+        public void Write(Stream stream)
+        {
+            using (StreamWriter sw = new StreamWriter(stream))
             {
                 foreach (string Comment in this.Comments)
                 {

--- a/Fantome.League/IO/SCB/SCBFile.cs
+++ b/Fantome.League/IO/SCB/SCBFile.cs
@@ -28,9 +28,15 @@ namespace Fantome.Libraries.League.IO.SCB
             }
         }
 
-        public SCBFile(string Location)
+        public SCBFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(Location)))
+
+        }
+
+        public SCBFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 string Magic = Encoding.ASCII.GetString(br.ReadBytes(8));
                 if (Magic != "r3d2Mesh")
@@ -79,10 +85,14 @@ namespace Fantome.Libraries.League.IO.SCB
                 }
             }
         }
-
-        public void Write(string Location)
+        public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(Location)))
+            Write(File.Create(fileLocation));
+        }
+
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write("r3d2Mesh".ToCharArray());
                 bw.Write((UInt16)3);

--- a/Fantome.League/IO/SCO/SCOFile.cs
+++ b/Fantome.League/IO/SCO/SCOFile.cs
@@ -24,9 +24,15 @@ namespace Fantome.Libraries.League.IO.SCO
                 this.Faces.Add(new SCOFace(new UInt16[] { Indices[i], Indices[i + 1], Indices[i + 2] }, "lambert1", new Vector2[] { UV[i], UV[i + 1], UV[i + 2]}));
             }
         }
-        public SCOFile(string Location)
+
+        public SCOFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (StreamReader sr = new StreamReader(Location))
+
+        }
+        public SCOFile(Stream stream)
+        {
+            using (StreamReader sr = new StreamReader(stream))
             {
                 char[] SplittingArray = new char[] { ' ' };
                 string[] input = null;

--- a/Fantome.League/IO/SKN/SKNFile.cs
+++ b/Fantome.League/IO/SKN/SKNFile.cs
@@ -61,9 +61,14 @@ namespace Fantome.Libraries.League.IO.SKN
             }
         }
 
-        public SKNFile(string Location)
+        public SKNFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(Location)))
+
+        }
+        public SKNFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 UInt32 Magic = br.ReadUInt32();
                 if (Magic != 0x00112233)
@@ -114,9 +119,13 @@ namespace Fantome.Libraries.League.IO.SKN
             }
         }
 
-        public void Write(string Location)
+        public void Write(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(Location)))
+            Write(File.Create(fileLocation));
+        }
+        public void Write(Stream stream)
+        {
+            using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write(0x00112233);
                 bw.Write((UInt16)2);

--- a/Fantome.League/IO/WAD/WADFile.cs
+++ b/Fantome.League/IO/WAD/WADFile.cs
@@ -25,8 +25,18 @@ namespace Fantome.Libraries.League.IO.WAD
         /// </summary>
         /// <param name="fileLocation">The location to read from</param>
         public WADFile(string fileLocation)
+            : this(File.OpenRead(fileLocation))
         {
-            using (BinaryReader br = new BinaryReader(File.OpenRead(fileLocation)))
+
+        }
+
+        /// <summary>
+        /// Reads a <see cref="WADFile"/> from the specified stream
+        /// </summary>
+        /// <param name="stream">The stream to read from</param>
+        public WADFile(Stream stream)
+        {
+            using (BinaryReader br = new BinaryReader(stream))
             {
                 string magic = Encoding.ASCII.GetString(br.ReadBytes(2));
                 if (magic != "RW")


### PR DESCRIPTION
1. Changed arguments for file read/write functions to take ``Stream`` instead of ``string``
2. Adjusted read constructors with ``string fileLocation`` to all use ``File.ReadOpen`` as to open files in readonly mode
3. Adjusted write functions with ``string fileLocation`` to all use ``File.Create`` as to allways create file or completly rewrite if one exists instead of append