### PR TITLE
Fix file stream not being closed when saving WAD file

### DIFF
--- a/Fantome.League/IO/WAD/WADFile.cs
+++ b/Fantome.League/IO/WAD/WADFile.cs
@@ -215,7 +215,11 @@ namespace Fantome.Libraries.League.IO.WAD
         /// <param name="minor">Which minor version this <see cref="WADFile"/> should be saved as</param>
         public void Write(string fileLocation, byte major, byte minor)
         {
-            Write(File.Create(fileLocation), major, minor);
+            FileStream fs = File.Create(fileLocation);
+
+            Write(fs, major, minor);
+
+            fs.Close();
         }
 
         /// <summary>


### PR DESCRIPTION
While using Obsidian, I noticed that a saved WAD file is still considered open by the program even once it is done writing. Turns out it's only because the file stream wasn't being closed once the file was written. This small change fixes that issue.