### PR TITLE
Fix parsing of bin value type as they appear in new bins

### DIFF
--- a/Fantome.League/IO/BIN/BINContainer.cs
+++ b/Fantome.League/IO/BIN/BINContainer.cs
@@ -26,7 +26,7 @@ namespace Fantome.Libraries.League.IO.BIN
         {
             this.Parent = parent;
 
-            this.EntryType = (BINValueType)br.ReadByte();
+            this.EntryType = BINValue.ByteToBINValueType(br.ReadByte());
             uint size = br.ReadUInt32();
             uint valueCount = br.ReadUInt32();
 

--- a/Fantome.League/IO/BIN/BINMap.cs
+++ b/Fantome.League/IO/BIN/BINMap.cs
@@ -34,8 +34,8 @@ namespace Fantome.Libraries.League.IO.BIN
         {
             this.Parent = parent;
 
-            this.KeyType = (BINValueType)br.ReadByte();
-            this.ValueType = (BINValueType)br.ReadByte();
+            this.KeyType = BINValue.ByteToBINValueType(br.ReadByte());
+            this.ValueType = BINValue.ByteToBINValueType(br.ReadByte());
             uint size = br.ReadUInt32();
             uint valueCount = br.ReadUInt32();
 

--- a/Fantome.League/IO/BIN/BINOptional.cs
+++ b/Fantome.League/IO/BIN/BINOptional.cs
@@ -14,7 +14,7 @@ namespace Fantome.Libraries.League.IO.BIN
         public BINOptional(BinaryReader br, IBINValue parent)
         {
             this.Parent = parent;
-            this.Type = (BINValueType)br.ReadByte();
+            this.Type = BINValue.ByteToBINValueType(br.ReadByte());;
             byte valueCount = br.ReadByte(); //????
 
             if(valueCount > 1)

--- a/Fantome.League/IO/BIN/BINValue.cs
+++ b/Fantome.League/IO/BIN/BINValue.cs
@@ -50,7 +50,7 @@ namespace Fantome.Libraries.League.IO.BIN
                     int startIndex = property.IndexOf('[');
                     int valueIndex = int.Parse(property.Substring(startIndex + 1, property.IndexOf(']') - startIndex - 1));
 
-                    if(this.Type == BINValueType.Container && 
+                    if(this.Type == BINValueType.Container &&
                         (this.Value as BINContainer).EntryType == BINValueType.Embedded ||
                         (this.Value as BINContainer).EntryType == BINValueType.Structure)
                     {
@@ -130,7 +130,7 @@ namespace Fantome.Libraries.League.IO.BIN
                     }
 
                 }
-                
+
                 return null;
             }
         }
@@ -159,7 +159,7 @@ namespace Fantome.Libraries.League.IO.BIN
             if (this.Type == null)
             {
                 this.Property = br.ReadUInt32();
-                this.Type = (BINValueType)br.ReadByte();
+                this.Type = BINValue.ByteToBINValueType(br.ReadByte());
                 this._typeRead = true;
             }
 
@@ -610,6 +610,11 @@ namespace Fantome.Libraries.League.IO.BIN
             {
                 return false;
             }
+        }
+
+        public static BINValueType ByteToBINValueType(byte value)
+        {
+            return (value >= 0x80) ? (BINValueType) (value - 0x80 + 18) : (BINValueType) value;
         }
     }
 


### PR DESCRIPTION
Apparently, the MSB is not part of the enum and indicates some kind of bit flag, I don't know what though. This fix makes everything work again